### PR TITLE
Use correct domain

### DIFF
--- a/directory/package.json
+++ b/directory/package.json
@@ -1,5 +1,5 @@
 {
-  "homepage": "https://btcpayserver.github.io/directory.btcpayserver.org/",
+  "homepage": "https://directory.btcpayserver.org/",
   "name": "directory",
   "version": "0.1.0",
   "private": true,

--- a/directory/public/CNAME
+++ b/directory/public/CNAME
@@ -1,0 +1,1 @@
+directory.btcpayserver.org


### PR DESCRIPTION
**PLEASE DON'T MERGE UNTIL THE DOMAINS DNS RECORD IS SWITCHED.**

Prepares the production deployment for the correct domain.

In preparation for that to work, we need to set the DNS entry for `directory.btcpayserver.org` to a `CNAME` record pointing to `btcpayserver.github.io`.

See the [GH Pages docs on "Configuring a subdomain"](https://help.github.com/en/github/working-with-github-pages/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain).