### PR TITLE
Add PikaSim - Privacy-focused eSIM provider

### DIFF
--- a/src/components/Directory/List.js
+++ b/src/components/Directory/List.js
@@ -1764,4 +1764,12 @@ export const list = [
   subType: "fashion",
   description: "T-shirts and hats. If you are in Japan, we will deliver your items anonymously.",
 },
+{
+  name: "PikaSim",
+  url: "https://pikasim.com",
+  twitter: "@PikaSim",
+  type: "merchants",
+  subType: "holiday-travel",
+  description: "Privacy-focused eSIM provider for 170+ countries. No account required, no ID upload. Accepts Bitcoin on-chain, Lightning Network, and Monero via self-hosted BTCPay Server.",
+},
 ];


### PR DESCRIPTION
## New Entry: PikaSim

**Name:** PikaSim  
**URL:** https://pikasim.com  
**Type:** merchants  
**SubType:** holiday-travel  
**Twitter:** @PikaSim

### Description
Privacy-focused eSIM provider for 170+ countries. No account required, no ID upload. Accepts Bitcoin on-chain, Lightning Network, and Monero via self-hosted BTCPay Server.

### Why holiday-travel?
PikaSim provides eSIMs for international travelers - similar to CheapAir.com which is also in this category. We help travelers stay connected privately while abroad.

### BTCPay Server Usage
- Self-hosted BTCPay Server instance
- Accepts Bitcoin on-chain and Lightning Network
- Also accepts Monero
- No KYC requirements
- See our Bitcoin payment guide: https://pikasim.com/pay-with-bitcoin

### Privacy Features
- No account required to purchase
- No ID upload needed
- No email required for crypto payments
- Instant eSIM delivery
- 170+ countries supported

Submitted by: codebruinc (pikasim.com)