### PR TITLE
feat: OpenStreetMap OAuth Bounce Page - BTC Map Plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@tailwindcss/vite": "^4.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-basic-ssl": "^2.3.0",
         "@vitejs/plugin-react": "^4.3.4",
         "tailwindcss": "^4.0.0",
         "tsx": "^4.21.0",
@@ -1930,6 +1931,19 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-basic-ssl": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.3.0.tgz",
+      "integrity": "sha512-bdyo8rB3NnQbikdMpHaML9Z1OZPBu6fFOBo+OtxsBlvMJtysWskmBcnbIDhUqgC8tcxNv/a+BcV5U+2nQMm1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@tailwindcss/vite": "^4.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-basic-ssl": "^2.3.0",
     "@vitejs/plugin-react": "^4.3.4",
     "tailwindcss": "^4.0.0",
     "tsx": "^4.21.0",

--- a/public/plugins/btcmap/oauth/callback/index.html
+++ b/public/plugins/btcmap/oauth/callback/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow">
+  <title>BTC Map Plugin — Redirecting...</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      background: #1e1e2e;
+      color: #cdd6f4;
+    }
+    .container {
+      text-align: center;
+      padding: 2rem;
+      max-width: 32rem;
+    }
+    .error { color: #f38ba8; }
+    h1 { font-size: 1.25rem; margin-bottom: 0.5rem; }
+    p { margin: 0.5rem 0; line-height: 1.5; }
+  </style>
+</head>
+<body>
+  <div class="container" id="message">
+    <p>Redirecting back to your BTCPay Server...</p>
+  </div>
+  <script>
+    (function () {
+      var messageEl = document.getElementById('message');
+
+      function showError(msg) {
+        messageEl.innerHTML =
+          '<h1 class="error">Redirect failed</h1>' +
+          '<p>' + msg + '</p>' +
+          '<p>Please return to your BTCPay Server and try connecting again.</p>';
+      }
+
+      var params = new URLSearchParams(window.location.search);
+      var code = params.get('code');
+      var state = params.get('state');
+
+      // OSM may redirect here with an error (e.g. user declined authorization).
+      var oauthError = params.get('error');
+      if (oauthError) {
+        showError('OpenStreetMap returned an error: ' + oauthError);
+        return;
+      }
+
+      if (!code || !state) {
+        showError('Missing authorization parameters.');
+        return;
+      }
+
+      var origin;
+      try {
+        // state is base64-encoded (standard or url-safe) UTF-8 origin URL.
+        var normalized = state.replace(/-/g, '+').replace(/_/g, '/');
+        // Pad to multiple of 4.
+        while (normalized.length % 4) normalized += '=';
+        origin = atob(normalized);
+      } catch (e) {
+        showError('Invalid state parameter.');
+        return;
+      }
+
+      var url;
+      try {
+        url = new URL(origin);
+      } catch (e) {
+        showError('State did not decode to a valid URL.');
+        return;
+      }
+
+      // Only HTTPS is allowed in production. HTTP is permitted for localhost-only
+      // dev scenarios (127.0.0.1 / localhost). This is a security boundary: if an
+      // attacker crafts a malicious state pointing to their own server, PKCE alone
+      // makes the intercepted code useless without the code_verifier — but we still
+      // refuse to forward codes to arbitrary origins.
+      var isLocalhost = url.hostname === '127.0.0.1' || url.hostname === 'localhost';
+      if (url.protocol !== 'https:' && !(url.protocol === 'http:' && isLocalhost)) {
+        showError('Only HTTPS origins are allowed (or http://localhost for development).');
+        return;
+      }
+
+      // Rebuild the target URL: {origin}/plugins/btcmap/oauth/callback?code={code}
+      // We deliberately do not forward state onward — the BTCPay instance already
+      // has the PKCE code_verifier in its settings and does not need state to
+      // identify the in-flight flow.
+      url.pathname = '/plugins/btcmap/oauth/callback';
+      url.search = '';
+      url.searchParams.set('code', code);
+
+      // Use replace() so the auth code does not remain in this domain's history.
+      window.location.replace(url.toString());
+    })();
+  </script>
+</body>
+</html>

--- a/public/plugins/btcmap/oauth/callback/index.html
+++ b/public/plugins/btcmap/oauth/callback/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="robots" content="noindex, nofollow">
+  <meta name="referrer" content="no-referrer">
   <title>BTC Map Plugin — Redirecting...</title>
   <style>
     body {
@@ -27,18 +28,20 @@
   </style>
 </head>
 <body>
-  <div class="container" id="message">
-    <p>Redirecting back to your BTCPay Server...</p>
+  <div class="container">
+    <p id="status">Redirecting back to your BTCPay Server...</p>
+    <div id="error-box" style="display:none">
+      <h1 class="error">Redirect failed</h1>
+      <p id="error-detail"></p>
+      <p>Please return to your BTCPay Server and try connecting again.</p>
+    </div>
   </div>
   <script>
     (function () {
-      var messageEl = document.getElementById('message');
-
       function showError(msg) {
-        messageEl.innerHTML =
-          '<h1 class="error">Redirect failed</h1>' +
-          '<p>' + msg + '</p>' +
-          '<p>Please return to your BTCPay Server and try connecting again.</p>';
+        document.getElementById('status').style.display = 'none';
+        document.getElementById('error-detail').textContent = msg;
+        document.getElementById('error-box').style.display = '';
       }
 
       var params = new URLSearchParams(window.location.search);
@@ -82,6 +85,11 @@
       // attacker crafts a malicious state pointing to their own server, PKCE alone
       // makes the intercepted code useless without the code_verifier — but we still
       // refuse to forward codes to arbitrary origins.
+      //
+      // NOTE: This is intentionally an open redirect to any HTTPS origin — BTCPay
+      // instances live at arbitrary domains, so we cannot allowlist hosts. PKCE
+      // mitigates auth-code theft; the fixed pathname and single-param query
+      // constrain generic abuse of this endpoint as a redirector.
       var isLocalhost = url.hostname === '127.0.0.1' || url.hostname === 'localhost';
       if (url.protocol !== 'https:' && !(url.protocol === 'http:' && isLocalhost)) {
         showError('Only HTTPS origins are allowed (or http://localhost for development).');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import basicSsl from "@vitejs/plugin-basic-ssl";
 import path from "path";
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), basicSsl()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,11 @@ import basicSsl from "@vitejs/plugin-basic-ssl";
 import path from "path";
 
 export default defineConfig({
-  plugins: [react(), tailwindcss(), basicSsl()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    ...(process.env.HTTPS ? [basicSsl()] : []),
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Add OAuth bounce page for BTC Map plugin

This PR adds a single static HTML file at `public/plugins/btcmap/oauth/callback/index.html` to support the OAuth 2.0 flow for the upcoming BTC Map plugin for BTCPay Server.

### Why this is needed

The BTC Map plugin lets BTCPay merchants automatically list their stores on btcmap.org by writing Bitcoin acceptance tags to OpenStreetMap. Writing to OSM requires OAuth 2.0 authentication.

OSM requires every OAuth app to pre-register exact-match redirect URIs — wildcards aren't supported. Since every BTCPay Server instance runs on a different domain (`btcpay.merchant1.com`, `btcpay.merchant2.org`, etc.), there's no way to register a redirect URI per instance.

This static page solves that by acting as a stateless redirect bouncer:
1. Plugin sends the admin to OSM with the originating BTCPay URL encoded in the OAuth `state` parameter
2. OSM redirects to this single registered URL with the auth code
3. The page reads `state`, decodes the origin, and redirects the browser back to the originating BTCPay instance with the code

### Why it's safe

- No server-side code, no data storage, no maintenance burden — pure client-side redirect
- The plugin uses PKCE (Proof Key for Code Exchange), so even if an attacker crafted a malicious `state` to steal the auth code, it would be useless without the `code_verifier` that only exists in memory on the originating BTCPay instance
- The page validates that the decoded origin is a valid HTTPS URL before redirecting