### PR TITLE
Refresh PikaSim entry: add USDT + shielded Zcash, phone numbers

### DIFF
--- a/src/data/merchants.json
+++ b/src/data/merchants.json
@@ -1106,7 +1106,7 @@
   {
     "name": "PikaSim",
     "url": "https://pikasim.com",
-    "description": "Privacy-focused eSIM provider for 170+ countries. No account required, no ID upload. Accepts Bitcoin on-chain, Lightning Network, and Monero via self-hosted BTCPay Server.",
+    "description": "Privacy-focused eSIMs and real carrier phone numbers for 190+ countries. No account, ID, or email. Accepts Bitcoin on-chain, Lightning, Monero, USDT, and shielded Zcash via self-hosted BTCPay Server.",
     "type": "merchants",
     "subType": "holiday-travel",
     "twitter": "@PikaSim"


### PR DESCRIPTION
Updates the existing **PikaSim** merchant entry. Since it was added, PikaSim has:

- added **USDT** and **shielded Zcash** payment rails alongside the existing Bitcoin on-chain, Lightning and Monero (all via our self-hosted BTCPay Server),
- launched **real carrier phone numbers** (voice, SMS, data) in addition to data eSIMs, and
- expanded coverage from 170+ to **190+ countries**.

Description stays within the 250-char limit (199 chars). Only the `description` field changed; `type`/`subType`/`twitter` are unchanged.

Authored-by: CodeBru [codebru.com]